### PR TITLE
Use update_counters to solve concurrency issues.

### DIFF
--- a/lib/acts_as_account/journal.rb
+++ b/lib/acts_as_account/journal.rb
@@ -53,8 +53,7 @@ module ActsAsAccount
           :reference => reference,
           :valuta => valuta)
 
-        account.reload.balance += posting.amount
-        account.postings_count += 1
+        account.class.update_counters account.id, :postings_count => 1, :balance => posting.amount
 
         posting.save(:validate => false)
         account.save(:validate => false)


### PR DESCRIPTION
Hi,

At https://github.com/rallysf/acts_as_account, we noticed our account.postings_count and account.balance differing from the sum of our postings for that account and the postings sum respectively. In examining the issue, we found that it was a concurrency issue when an account received multiple postings. Previously, the lock on the account rows were being undone by the use of .reload.

In testing locally, using ab with varying concurrency levels, we found that both update_counters and just removing the .reload both resulted in proper accounting between the postings and the account's view of those postings.  I viewed the account's balances as being treated like other counters in rails, thus the use of update_counters in this change.
